### PR TITLE
Removed callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,15 +105,14 @@ class GoogleWebfontsPlugin {
 			} else {
 				cb()
 			}
-			compilation.plugin("html-webpack-plugin-before-html-generation", (data, cb) => {
+			compilation.plugin("html-webpack-plugin-before-html-generation", (data) => {
 				if (local && (data.assets.publicPath.indexOf("://") !== -1 || data.assets.publicPath.indexOf(":") !== -1)) {
-                    data.assets.css.push(data.assets.publicPath + cssFile);
-                } else if (local) {
-                    data.assets.css.push(path.posix.join(data.assets.publicPath, cssFile));
-                } else {
-                    data.assets.css.push(cssUrl(fonts));
-                }
-				cb(null, data)
+          data.assets.css.push(data.assets.publicPath + cssFile);
+        } else if (local) {
+          data.assets.css.push(path.posix.join(data.assets.publicPath, cssFile));
+        } else {
+          data.assets.css.push(cssUrl(fonts));
+        }
 			})
 			compilation.plugin("additional-assets", cb => {
 				compilation.chunks.push(this.chunk)


### PR DESCRIPTION
Removed callback from `html-webpack-plugin-before-html-generation`, because it is not returning a callback anymore.